### PR TITLE
XForwardedFilter toAbsolute(null) patch

### DIFF
--- a/src/main/java/fr/xebia/servlet/filter/XForwardedFilter.java
+++ b/src/main/java/fr/xebia/servlet/filter/XForwardedFilter.java
@@ -625,6 +625,9 @@ public class XForwardedFilter implements Filter {
          */
         protected String toAbsolute(String location) {
             String url = location;
+            if (url == null) {
+                url = "";
+            }
             boolean leadingSlash = url.startsWith("/");
             StringBuilder urlBuilder = new StringBuilder();
             if (leadingSlash || !hasScheme(url)) {

--- a/src/test/java/fr/xebia/servlet/filter/XForwardedFilterTest.java
+++ b/src/test/java/fr/xebia/servlet/filter/XForwardedFilterTest.java
@@ -693,6 +693,7 @@ public class XForwardedFilterTest {
             response.toAbsolute(request.getContextPath() + "/relativeURI"));
         assertEquals("absolute uri", "https://server/othercontext/uri",
             response.toAbsolute("https://server/othercontext/uri"));
+        assertEquals("null uri", "http://localhost/context/dir/", response.toAbsolute(null));
     }
     
 }


### PR DESCRIPTION
When a `response.sendRedirect(null)` is called the `toAbsolute` method recieves a `null` parameter. This results in a `NullPointerException`. I've added a unit test to reproduce this exception and fixed the implementation to return the current absolute path. I'm not sure if this is the most obvious solution but at least it is more obvious than a `NullPointerException` :-)

Kind regards,
- Marc van Andel
